### PR TITLE
Fix efr firework interaction

### DIFF
--- a/src/main/java/xonin/backhand/ServerEventsHandler.java
+++ b/src/main/java/xonin/backhand/ServerEventsHandler.java
@@ -33,7 +33,6 @@ public class ServerEventsHandler {
             ItemStack offhandItem = BackhandUtils.getOffhandItem(player);
             if ((mainhandItem == null || mainhandItem.getItem() != Items.fireworks) && offhandItem != null
                 && offhandItem.getItem() == Items.fireworks) {
-                BackhandUtils.swapOffhandItem(player);
                 fireworkHotSwapped = 1;
             }
         }

--- a/src/main/java/xonin/backhand/ServerTickHandler.java
+++ b/src/main/java/xonin/backhand/ServerTickHandler.java
@@ -148,6 +148,7 @@ public class ServerTickHandler {
         if (ServerEventsHandler.fireworkHotSwapped > 0) {
             ServerEventsHandler.fireworkHotSwapped--;
         } else if (ServerEventsHandler.fireworkHotSwapped == 0) {
+            BackhandUtils.swapOffhandItem(player);
             ServerEventsHandler.fireworkHotSwapped--;
             MinecraftForge.EVENT_BUS.post(
                 new PlayerInteractEvent(

--- a/src/main/java/xonin/backhand/api/core/BackhandUtils.java
+++ b/src/main/java/xonin/backhand/api/core/BackhandUtils.java
@@ -73,10 +73,13 @@ public class BackhandUtils {
     }
 
     public static void swapOffhandItem(EntityPlayer player) {
-        final ItemStack mainhandItem = player.getCurrentEquippedItem();
-        final ItemStack offhandItem = BackhandUtils.getOffhandItem(player);
+        final ItemStack mainhandItem = getLegalStack(player.getCurrentEquippedItem());
+        final ItemStack offhandItem = getLegalStack(BackhandUtils.getOffhandItem(player));
         BackhandUtils.setPlayerCurrentItem(player, offhandItem);
         BackhandUtils.setPlayerOffhandItem(player, mainhandItem);
+        if (Backhand.UseInventorySlot) {
+            player.inventoryContainer.detectAndSendChanges();
+        }
     }
 
     public static void setPlayerCurrentItem(EntityPlayer player, ItemStack stack) {
@@ -514,5 +517,13 @@ public class BackhandUtils {
         // Reset stuff so that vanilla doesn't do anything
         entityPlayer.clearItemInUse();
         return null;
+    }
+
+    public static ItemStack getLegalStack(ItemStack stack) {
+        if (stack != null && stack.stackSize == 0) {
+            return null;
+        }
+
+        return stack;
     }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/Backhand/issues/12

Case 1 is fixed by calling  `player.inventoryContainer.detectAndSendChanges()` after an offhand swap if the `"Use inventory slot"` config is turned on.

Case 2:
Switches the `BackhandUtils.swapOffhandItem()` call to be in the same tick as the call to swap back fixes the weird phantom stacks.  This however revealed a different problem when the itemstack was depleted as the stack transferred to the offhand was one with a stacksize of 0, which created an infinite stack when swapped back to main hand. There was also a chance of this happening before if you scrolled through the hotbar fast enough.
Any itemstack with a size of 0 is forcibly nullified now which combined with the other fix handles case 2.

Scrolling through the hotbar while using fireworks works as expected now on both settings.
![bh_firework](https://github.com/user-attachments/assets/147c2f29-0ede-4e93-9354-43cb38b8b282)
