### PR TITLE
Fix some item uis not opening when something is in offhand

### DIFF
--- a/src/main/java/xonin/backhand/client/ClientEventHandler.java
+++ b/src/main/java/xonin/backhand/client/ClientEventHandler.java
@@ -13,7 +13,6 @@ import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
-import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 
@@ -39,10 +38,7 @@ public class ClientEventHandler {
 
     public static boolean prevInvTweaksAutoRefill;
     public static boolean prevInvTweaksBreakRefill;
-
     public static int invTweaksDelay;
-
-    public static int renderPass;
 
     @SubscribeEvent
     public static void renderHotbarOverlay(RenderGameOverlayEvent event) {
@@ -130,11 +126,6 @@ public class ClientEventHandler {
             RenderItem.getInstance()
                 .renderItemOverlayIntoGUI(mc.fontRenderer, mc.getTextureManager(), itemstack, p_73832_2_, p_73832_3_);
         }
-    }
-
-    @SubscribeEvent
-    public static void onRenderHand(RenderHandEvent event) {
-        renderPass = event.renderPass;
     }
 
     /**

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinNetHandlerPlayServer.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinNetHandlerPlayServer.java
@@ -3,17 +3,22 @@ package xonin.backhand.mixins.early.minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement;
 import net.minecraft.server.management.ItemInWorldManager;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 
 import xonin.backhand.api.core.BackhandUtils;
 import xonin.backhand.api.core.IOffhandInventory;
+import xonin.backhand.packet.BackhandPacketHandler;
+import xonin.backhand.packet.OffhandCancelUsage;
 import xonin.backhand.utils.BackhandConfig;
 
 @Mixin(NetHandlerPlayServer.class)
@@ -40,6 +45,24 @@ public abstract class MixinNetHandlerPlayServer {
             target = "Lnet/minecraft/server/management/ItemInWorldManager;uncheckedTryHarvestBlock(III)V"))
     private boolean backhand$playerDigging(ItemInWorldManager instance, int l, int block, int i) {
         return BackhandConfig.OffhandBreakBlocks || !BackhandUtils.isUsingOffhand(playerEntity);
+    }
+
+    @Inject(
+        method = "processPlayerBlockPlacement",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraftforge/event/ForgeEventFactory;onPlayerInteract(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraftforge/event/entity/player/PlayerInteractEvent$Action;IIIILnet/minecraft/world/World;)Lnet/minecraftforge/event/entity/player/PlayerInteractEvent;",
+            remap = false),
+        cancellable = true)
+    private void backhand$itemUse(C08PacketPlayerBlockPlacement packetIn, CallbackInfo ci) {
+        if (BackhandUtils.isUsingOffhand(playerEntity)
+            && playerEntity.openContainer != playerEntity.inventoryContainer) {
+            // Client-side might still think it's using the offhand item, so we need to cancel the usage
+            if (!playerEntity.isUsingItem()) {
+                BackhandPacketHandler.sendPacketToPlayer(new OffhandCancelUsage(), playerEntity);
+            }
+            ci.cancel();
+        }
     }
 
     @WrapWithCondition(

--- a/src/main/java/xonin/backhand/packet/BackhandPacketHandler.java
+++ b/src/main/java/xonin/backhand/packet/BackhandPacketHandler.java
@@ -22,6 +22,7 @@ public final class BackhandPacketHandler {
         NETWORK.registerMessage(OffhandSyncItemPacket.Handler.class, OffhandSyncItemPacket.class, 0, Side.CLIENT);
         NETWORK.registerMessage(OffhandSyncOffhandUse.Handler.class, OffhandSyncOffhandUse.class, 1, Side.CLIENT);
         NETWORK.registerMessage(OffhandAnimationPacket.Handler.class, OffhandAnimationPacket.class, 2, Side.CLIENT);
+        NETWORK.registerMessage(OffhandCancelUsage.Handler.class, OffhandCancelUsage.class, 3, Side.CLIENT);
     }
 
     public static void sendPacketToPlayer(IMessage packet, EntityPlayer player) {

--- a/src/main/java/xonin/backhand/packet/OffhandCancelUsage.java
+++ b/src/main/java/xonin/backhand/packet/OffhandCancelUsage.java
@@ -1,0 +1,28 @@
+package xonin.backhand.packet;
+
+import net.minecraft.client.Minecraft;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+public class OffhandCancelUsage implements IMessage {
+
+    public OffhandCancelUsage() {}
+
+    @Override
+    public void fromBytes(ByteBuf buf) {}
+
+    @Override
+    public void toBytes(ByteBuf buf) {}
+
+    public static class Handler implements IMessageHandler<OffhandCancelUsage, IMessage> {
+
+        @Override
+        public IMessage onMessage(OffhandCancelUsage message, MessageContext ctx) {
+            Minecraft.getMinecraft().thePlayer.clearItemInUse();
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/Backhand/issues/60
The problem goes like so:
The client right clicks and executes main hand items action first, this might do absolutely nothing client-side but sends a use-packet to the server. Server receives that packet and if the item has a ui it needs to open it will then send a container packet back.

The packet can't be processed until the next tick at the very earliest and in the meantime the offhand sees that main hand did nothing and executes its action. This again sends a use-packet to the server which causes the server to think that the container it just told the client to open has already been closed and it then sends a packet telling the client to close it.

There is no way to tell that this will happen from client-side so we have to intercept the offhands use-packet server side and stop it from executing if a gui was opened. 
If the client had an item with some right-click action (sword, bow etc.) it still thinks that action was processed so we also have to send an extra packet telling the client to stop its funny business.

TL;DR:
Before:
CLIENT -> USE-PACKET -> SERVER -> CONTAINER-PACKET -> CLIENT -> USE-PACKET -> SERVER -> CLOSE-CONTAINER-PACKET -> CLIENT
After:
CLIENT -> USE-PACKET -> SERVER -> CONTAINER-PACKET -> CLIENT -> USE-PACKET -> SERVER goes nuhuh -> STOP-USING-OFFHAND-DUMMY-PACKET -> CLIENT
(this was a pita)