### PR TITLE
A bunch of (missing) GL state fixes

### DIFF
--- a/src/main/java/xonin/backhand/client/ClientEventHandler.java
+++ b/src/main/java/xonin/backhand/client/ClientEventHandler.java
@@ -172,11 +172,9 @@ public class ClientEventHandler {
 
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glDisable(GL11.GL_CULL_FACE);
-
         BackhandRenderHelper.renderOffhandItemIn3rdPerson(event.entityPlayer, biped, event.partialRenderTick);
-
-        GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glEnable(GL11.GL_CULL_FACE);
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/xonin/backhand/client/ClientEventHandler.java
+++ b/src/main/java/xonin/backhand/client/ClientEventHandler.java
@@ -169,7 +169,15 @@ public class ClientEventHandler {
 
         GL11.glPushMatrix();
         ModelBiped biped = event.renderer.modelBipedMain;
+
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glDisable(GL11.GL_CULL_FACE);
+
         BackhandRenderHelper.renderOffhandItemIn3rdPerson(event.entityPlayer, biped, event.partialRenderTick);
+
+        GL11.glEnable(GL11.GL_CULL_FACE);
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/xonin/backhand/client/utils/BackhandRenderHelper.java
+++ b/src/main/java/xonin/backhand/client/utils/BackhandRenderHelper.java
@@ -76,6 +76,8 @@ public final class BackhandRenderHelper {
 
             GL11.glTranslatef(-0.0625F, 0.4375F, 0.0625F);
 
+            GL11.glFrontFace(GL11.GL_CW);
+
             if (player.fishEntity != null && offhandItem.getItem() == Items.fishing_rod) {
                 offhandItem = new ItemStack(Items.stick);
             }
@@ -89,6 +91,7 @@ public final class BackhandRenderHelper {
             IItemRenderer customRenderer = MinecraftForgeClient
                 .getItemRenderer(offhandItem, IItemRenderer.ItemRenderType.EQUIPPED);
             if (customRenderer instanceof IOffhandRenderOptOut) {
+                GL11.glFrontFace(GL11.GL_CCW);
                 GL11.glPopMatrix();
                 return;
             }
@@ -169,6 +172,7 @@ public final class BackhandRenderHelper {
                 itemRenderer.renderItem(player, offhandItem, 0);
             }
 
+            GL11.glFrontFace(GL11.GL_CCW);
             GL11.glPopMatrix();
         }
     }


### PR DESCRIPTION
Missing `glDisable(GL11.GL_CULL_FACE)` in `render3rdPersonOffhand`
---

Fixes a bug where offhand item would render incorrectly if main hand item has 3d model

Before:

![GL_CULL_FACE_ORIGINAL](https://github.com/user-attachments/assets/ebfb8e58-b93d-4449-b7cf-0e251673a9ee)


After:

![GL_CULL_FACE_PR](https://github.com/user-attachments/assets/82b04915-bd3a-4b6c-839b-368c940912aa)


---

This is due to a deviation from vanilla code. 

Code from `RendererLivingEntity.class`, method - `doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V`:

```java
public void doRender(EntityLivingBase p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_, float p_76986_8_, float p_76986_9_)
	{
	...
GL11.glPushMatrix();
GL11.glDisable(GL11.GL_CULL_FACE);
	...
```

Code from `ClientEventHandler.class`, method - `render3rdPersonOffhand(Lnet/minecraftforge/client/event/RenderPlayerEvent$Specials$Post;)V`:

```java
GL11.glPushMatrix();
ModelBiped biped = event.renderer.modelBipedMain;
BackhandRenderHelper.renderOffhandItemIn3rdPerson(event.entityPlayer, biped, event.partialRenderTick);
GL11.glPopMatrix();
```

As you can see, there is no `GL11.glDisable(GL11.GL_CULL_FACE)` call in Backhand, which is what causes this bug

In more detail, this happens because of `GL11.glScalef(-1, 1, 1);` in `BackhandRenderHelper.renderOffhandItemIn3rdPerson`, (since glScale with a negative argument flips the normals, but the culling mode still remains CCW)


Missing `glEnable(GL12.GL_RESCALE_NORMAL)` in `render3rdPersonOffhand`
---

Fixes a bug that caused offhand blocks to have broken lighting

Before:


https://github.com/user-attachments/assets/11e489db-db5a-46db-b1de-fe96567bb9fe



After:


https://github.com/user-attachments/assets/701d5e9e-d1aa-4576-bd8f-306f0dbe9a3a



---

This is also due to a deviation from vanilla code. 

Code from `RendererLivingEntity.class`, method - `doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V`:

```java
public void doRender(EntityLivingBase p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_, float p_76986_8_, float p_76986_9_)
	{
	...
this.rotateCorpse(p_76986_1_, f4, f2, p_76986_9_);
float f5 = 0.0625F;
GL11.glEnable(GL12.GL_RESCALE_NORMAL);
	...
```

Code from `ClientEventHandler.class`, method - `render3rdPersonOffhand(Lnet/minecraftforge/client/event/RenderPlayerEvent$Specials$Post;)V`:

```java
GL11.glPushMatrix();
ModelBiped biped = event.renderer.modelBipedMain;
BackhandRenderHelper.renderOffhandItemIn3rdPerson(event.entityPlayer, biped, event.partialRenderTick);
GL11.glPopMatrix();
```

As you (also) can see, there is no `GL11.glEnable(GL12.GL_RESCALE_NORMAL)` call in Backhand, which is what causes this bug


`glFrontFace` changing
---

As already mentioned in the "Missing `GL_CULL_FACE`", glScale with a negative argument flips the normals, so disabling `GL_CULL_FACE` fixes this.

But not for some 3d models, because they enable `GL_CULL_FACE` in the middle of the render.

So, once we flip the normals, we also explicitly set `glFrontFace` to `GL_CW`.

So, even if some renderer intentionally enables `GL_CULL_FACE`, culling will work in the inverted mode.

Before:

![glFrontFace_ORIGINAL](https://github.com/user-attachments/assets/3f7607d5-f468-49b5-9492-219acb13322f)


After:

![glFrontFace_PR](https://github.com/user-attachments/assets/1aebfee5-7019-426e-bff8-191e3b8d88f9)







