### PR TITLE
Rework right click order

### DIFF
--- a/src/main/java/xonin/backhand/api/core/BackhandUtils.java
+++ b/src/main/java/xonin/backhand/api/core/BackhandUtils.java
@@ -14,8 +14,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemFood;
-import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.FakePlayer;
 
@@ -27,10 +25,6 @@ public final class BackhandUtils {
 
     public static final List<Class<? extends Item>> offhandPriorityItems = new ArrayList<>();
     public static final List<Class<? extends Item>> deprioritizedMainhand = new ArrayList<>();
-
-    static {
-        addOffhandPriorityItem(ItemFood.class, ItemPotion.class);
-    }
 
     public static void setPlayerOffhandItem(EntityPlayer player, @Nullable ItemStack stack) {
         ((IOffhandInventory) player.inventory).backhand$setOffhandItem(stack);

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -85,7 +85,8 @@ public abstract class MixinMinecraft {
 
         ItemStack mainHandItem = MAIN_HAND.getItem(thePlayer);
         ItemStack offhandItem = OFF_HAND.getItem(thePlayer);
-        EnumHand[] hands = backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
+        EnumHand[] hands = mainHandItem.getItemUseAction() == EnumAction.block
+            || backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
         for (EnumHand hand : hands) {
             ItemStack handStack = hand == MAIN_HAND ? mainHandItem : offhandItem;
             boolean continueUsage = switch (objectMouseOver.typeOfHit) {

--- a/src/main/java/xonin/backhand/utils/EnumHand.java
+++ b/src/main/java/xonin/backhand/utils/EnumHand.java
@@ -1,0 +1,22 @@
+package xonin.backhand.utils;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import xonin.backhand.api.core.BackhandUtils;
+
+public enum EnumHand {
+
+    MAIN_HAND,
+    OFF_HAND;
+
+    public ItemStack getItem(EntityPlayer player) {
+        return switch (this) {
+            case MAIN_HAND -> player.inventory.getCurrentItem();
+            case OFF_HAND -> BackhandUtils.getOffhandItem(player);
+        };
+    }
+
+    public static final EnumHand[] HANDS = { EnumHand.MAIN_HAND, EnumHand.OFF_HAND };
+    public static final EnumHand[] HANDS_REV = { EnumHand.OFF_HAND, EnumHand.MAIN_HAND };
+}


### PR DESCRIPTION
Tested on client and server

Offhand will have priority when the main hand's action is block (sword, shield)
Made to mimic how the offhand works in modern (main hand preferred until it cant/doesnt do anything)