### PR TITLE
Add bucket/IFluidContainerItem check to right click handler

### DIFF
--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -88,7 +88,6 @@ public abstract class MixinMinecraft {
         ItemStack mainHandItem = MAIN_HAND.getItem(thePlayer);
         ItemStack offhandItem = OFF_HAND.getItem(thePlayer);
         EnumHand[] hands = backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
-
         for (EnumHand hand : hands) {
             ItemStack handStack = hand == MAIN_HAND ? mainHandItem : offhandItem;
 
@@ -115,7 +114,7 @@ public abstract class MixinMinecraft {
                 default -> false;
             };
 
-            // edge case with bucket and having a placeable item/block in the other hand
+            // edge case with bucket/IFluidContainerItem and having a placeable item/block in the other hand
             if (handStack != null && handStack.getItem() != null
                 && (handStack.getItem() instanceof ItemBucket || handStack.getItem() instanceof IFluidContainerItem)) {
                 stopCheck = backhand$useRightClick(hand, handStack, this::backhand$rightClickItem);

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -13,11 +13,13 @@ import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fluids.IFluidContainerItem;
 
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
@@ -86,11 +88,12 @@ public abstract class MixinMinecraft {
         ItemStack mainHandItem = MAIN_HAND.getItem(thePlayer);
         ItemStack offhandItem = OFF_HAND.getItem(thePlayer);
         EnumHand[] hands = backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
+
         for (EnumHand hand : hands) {
             ItemStack handStack = hand == MAIN_HAND ? mainHandItem : offhandItem;
 
             if (hand == OFF_HAND) {
-                if (objectMouseOver.typeOfHit != MovingObjectType.ENTITY
+                if (objectMouseOver.typeOfHit == MovingObjectType.BLOCK
                     && !TorchHandler.shouldPlace(mainHandItem, offhandItem)) {
                     continue;
                 }
@@ -111,6 +114,12 @@ public abstract class MixinMinecraft {
                 }
                 default -> false;
             };
+
+            // edge case with bucket and having a placeable item/block in the other hand
+            if (handStack != null && handStack.getItem() != null
+                && (handStack.getItem() instanceof ItemBucket || handStack.getItem() instanceof IFluidContainerItem)) {
+                stopCheck = backhand$useRightClick(hand, handStack, this::backhand$rightClickItem);
+            }
 
             if (stopCheck) return;
         }


### PR DESCRIPTION
Otherwise when you go to pick up a fluid, if you have a placeable item/block in the other hand, it will place it first since the fluid pickup is in the item's onItemRightClick