### PR TITLE
Remove unneeded HarvestTool deprioritize with new changes

### DIFF
--- a/src/main/java/xonin/backhand/compat/TConstructCompat.java
+++ b/src/main/java/xonin/backhand/compat/TConstructCompat.java
@@ -18,7 +18,6 @@ import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import tconstruct.library.tools.HarvestTool;
 import tconstruct.library.weaponry.IWindup;
 import tconstruct.tools.TinkerToolEvents;
 import tconstruct.tools.TinkerTools;
@@ -63,7 +62,6 @@ public class TConstructCompat {
                         TinkerToolEvents.class.getConstructor()
                             .newInstance());
             } catch (Exception ignored) {}
-            BackhandUtils.addDeprioritizedMainhandItem(HarvestTool.class);
             return true;
         }
         return false;


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/Backhand/issues/125

Mainhand is processed then offhand by default
Ticon nearby slot placing is disabled when an item is in the offhand