### PR TITLE
Fix double right-clicks + TiC Block Placement

### DIFF
--- a/src/main/java/xonin/backhand/mixins/late/ticon/MixinHarvestTool.java
+++ b/src/main/java/xonin/backhand/mixins/late/ticon/MixinHarvestTool.java
@@ -1,6 +1,7 @@
 package xonin.backhand.mixins.late.ticon;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
@@ -18,7 +19,9 @@ public class MixinHarvestTool {
     @Inject(method = "onItemUse", at = @At("HEAD"), cancellable = true)
     private void backhand$onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
         float clickX, float clickY, float clickZ, CallbackInfoReturnable<Boolean> cir) {
-        if (BackhandUtils.getOffhandItem(player) != null) {
+        ItemStack offhandItem = BackhandUtils.getOffhandItem(player);
+        // If the player is holding another block, prioritize it over the TiC auto-place
+        if (offhandItem != null && offhandItem.getItem() instanceof ItemBlock) {
             cir.setReturnValue(false);
         }
     }


### PR DESCRIPTION
- Fixes some Items like Prospector's Scanner double-clicking (Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20644 , fixes some issues in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20476 though i couldn't replicate everything there)
- Fix TiC tools being overwritten at all times (now, it prioritizes offhand if it holds an ItemBlock)
- Safer `objectMouseOver.typeOfHit == MovingObjectType.BLOCK` checks 