### PR TITLE
Fix AE2 parts not placeable while held in offhand

### DIFF
--- a/src/main/java/xonin/backhand/api/core/BackhandUtils.java
+++ b/src/main/java/xonin/backhand/api/core/BackhandUtils.java
@@ -57,12 +57,18 @@ public final class BackhandUtils {
 
     public static boolean useOffhandItem(EntityPlayer player, boolean syncSlot, BooleanSupplier action) {
         int oldSlot = player.inventory.currentItem;
-        player.inventory.currentItem = ((IOffhandInventory) player.inventory).backhand$getOffhandSlot();
-        boolean result = action.getAsBoolean();
-        player.inventory.currentItem = oldSlot;
+        player.inventory.currentItem = getOffhandSlot(player);
+
         if (syncSlot && player.worldObj.isRemote) {
             Minecraft.getMinecraft().playerController.syncCurrentPlayItem();
         }
+        boolean result = action.getAsBoolean();
+        player.inventory.currentItem = oldSlot;
+
+        if (syncSlot && player.worldObj.isRemote) {
+            Minecraft.getMinecraft().playerController.syncCurrentPlayItem();
+        }
+
         return result;
     }
 


### PR DESCRIPTION
AE2 parts are placed with a packet that gets sent from client to server during PlayerInteractEvent, this fix ensures that the server will always be aware of which hand is used during that event by forcing a slot sync prior to running any action.

This should be perfectly safe as all actions run client-side will force a sync anyways, this just runs the sync slightly earlier.