### PR TITLE
Fix npe caused by previous inv desync fix

### DIFF
--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinNetHandlerPlayServer.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinNetHandlerPlayServer.java
@@ -82,7 +82,7 @@ public abstract class MixinNetHandlerPlayServer {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V"))
     private boolean backhand$fixInvUpdateBlockage(Container container, @Local Slot slot) {
         // Only updates offhand slot to prevent blocking main inventory updates
-        if (BackhandUtils.isUsingOffhand(playerEntity)) {
+        if (slot != null && BackhandUtils.isUsingOffhand(playerEntity)) {
             ItemStack itemstack = slot.getStack();
             ItemStack itemstack1 = container.inventoryItemStacks.get(slot.slotNumber);
 


### PR DESCRIPTION
Honestly no clue how that slot is ever possibly null (vanilla doesn't even null check it either??)
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21366