### PR TITLE
Fix crash when holding TC wand with equal exchange in offhand

### DIFF
--- a/src/main/java/xonin/backhand/mixins/late/thaumcraft/MixinClientTickEventsFML.java
+++ b/src/main/java/xonin/backhand/mixins/late/thaumcraft/MixinClientTickEventsFML.java
@@ -61,7 +61,8 @@ public abstract class MixinClientTickEventsFML {
         if (off != null && (main == null
             || !(main.getItem() instanceof ItemWandCasting || main.getItem() instanceof ItemSanityChecker))) {
             if (off.getItem() instanceof ItemWandCasting) {
-                renderCastingWandHud(event.renderTickTime, player, time, off);
+                BackhandUtils
+                    .useOffhandItem(player, () -> renderCastingWandHud(event.renderTickTime, player, time, off));
             } else if (off.getItem() instanceof ItemSanityChecker) {
                 renderSanityHud(event.renderTickTime, player, time);
             }


### PR DESCRIPTION
This fix shouldn't technically be necessary, but thaumcraft does some very silly stuff as per usual...
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21551