### PR TITLE
fix: offhand item switching animations

### DIFF
--- a/src/main/java/xonin/backhand/client/hooks/ItemRendererHooks.java
+++ b/src/main/java/xonin/backhand/client/hooks/ItemRendererHooks.java
@@ -24,23 +24,24 @@ public class ItemRendererHooks {
         EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
         if (BackhandUtils.isUsingOffhand(player)) return;
 
-        ItemStack mainhandItem = player.getCurrentEquippedItem();
-        ItemStack offhandItem = BackhandUtils.getOffhandItem(player);
-        if (!BackhandConfig.EmptyOffhand && !BackhandConfigClient.RenderEmptyOffhandAtRest && offhandItem == null) {
-            return;
+        ItemStack renderedMainhandItem = Minecraft.getMinecraft().entityRenderer.itemRenderer.itemToRender;
+        ItemStack renderedOffhandItem = BackhandRenderHelper.itemRenderer.itemToRender;
+        if (!BackhandConfigClient.RenderEmptyOffhandAtRest && renderedOffhandItem == null) {
+            if (!BackhandConfig.EmptyOffhand) {
+                return;
+            }
+
+            if (((IBackhandPlayer) player).getOffSwingProgress(frame) == 0) {
+                return;
+            }
         }
 
-        if (offhandItem == null && !BackhandConfigClient.RenderEmptyOffhandAtRest
-            && ((IBackhandPlayer) player).getOffSwingProgress(frame) == 0) {
-            return;
-        }
-
-        if (usesBothHands(mainhandItem)) {
+        if (usesBothHands(renderedMainhandItem)) {
             return;
         }
 
         BackhandRenderHelper.firstPersonFrame = frame;
-        if (usesBothHands(offhandItem)) {
+        if (usesBothHands(renderedOffhandItem)) {
             BackhandUtils
                 .useOffhandItem(player, false, () -> BackhandRenderHelper.itemRenderer.renderItemInFirstPerson(frame));
         } else {


### PR DESCRIPTION
Rendering must use the itemrenderers `itemToRender`, which is different from the actually held item during the animation of switching between an empty hand and an item.

Fixes #159

Before:  
(Notice the offhand arm briefly appearing, and the offhand item instantly disappearing instead of fading out)

https://github.com/user-attachments/assets/a92e547a-1f64-4c70-ba61-6d8a7c0d730d

After:

https://github.com/user-attachments/assets/82e2f04b-58c0-461f-8172-961cbe36f44b

**Not tested in full pack** because I don't have a recent pack version instance set up.
