### PR TITLE
Fix offhand item clipping through custom armor models

### DIFF
--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinRenderPlayer.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinRenderPlayer.java
@@ -39,7 +39,7 @@ public class MixinRenderPlayer {
         }
         return original.call(player);
     }
-    
+
     @WrapOperation(
         method = "shouldRenderPass(Lnet/minecraft/client/entity/AbstractClientPlayer;IF)I",
         at = @At(

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinRenderPlayer.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinRenderPlayer.java
@@ -1,13 +1,16 @@
 package xonin.backhand.mixins.early.minecraft;
 
 import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -18,6 +21,9 @@ import xonin.backhand.api.core.BackhandUtils;
 
 @Mixin(RenderPlayer.class)
 public class MixinRenderPlayer {
+
+    @Shadow
+    public ModelBiped modelBipedMain;
 
     @WrapOperation(
         method = "renderEquippedItems(Lnet/minecraft/client/entity/AbstractClientPlayer;F)V",
@@ -32,5 +38,23 @@ public class MixinRenderPlayer {
             return null;
         }
         return original.call(player);
+    }
+    
+    @WrapOperation(
+        method = "shouldRenderPass(Lnet/minecraft/client/entity/AbstractClientPlayer;IF)I",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraftforge/client/ForgeHooksClient;getArmorModel(Lnet/minecraft/entity/EntityLivingBase;Lnet/minecraft/item/ItemStack;ILnet/minecraft/client/model/ModelBiped;)Lnet/minecraft/client/model/ModelBiped;",
+            remap = false))
+    private ModelBiped backhand$copyHeldItemToCustomArmorModel(EntityLivingBase entity, ItemStack stack, int slot,
+        ModelBiped _default, Operation<ModelBiped> original) {
+        ModelBiped model = original.call(entity, stack, slot, _default);
+        if (model != _default) {
+            model.heldItemLeft = modelBipedMain.heldItemLeft;
+            model.heldItemRight = modelBipedMain.heldItemRight;
+            model.aimedBow = modelBipedMain.aimedBow;
+            model.isSneak = modelBipedMain.isSneak;
+        }
+        return model;
     }
 }


### PR DESCRIPTION
Custom armor models do not receive heldItemLeft, heldItemRight, aimedBow, or isSneak from the main player model because ForgeHooksClient.getArmorModel() returns the custom model without copying these properties. Vanilla only copies onGround, isRiding, and isChild afterwards.

As a result, the armor’s arm remains in its default pose while the offhand item is positioned on a bent arm, causing the item to visually clip through the armor.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24181