### PR TITLE
Prevent offhand taking priority when watering CropsNH crops

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,6 +53,7 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
     compileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
+    compileOnly("com.github.GTNewHorizons:CropsNH:2.0.49:dev")
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.7-backhand:dev") {
         exclude module: "Backhand"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,28 +34,28 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.9.47:dev")
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.46-GTNH:dev") {transitive = false}
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.84-GTNH:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.65:dev")
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.68-GTNH:dev") {transitive = false}
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.97-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev") {transitive = false}
     compileOnly(rfg.deobf('maven.modrinth:etfuturum:2.6.2')) {transitive = false}
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.20-GTNH:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:Draconic-Evolution:1.5.21-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.27-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:Draconic-Evolution:1.5.26-GTNH:dev") {transitive = false}
     // pulls in ae2 for the mixin dep
-    compileOnly("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.13:dev")
+    compileOnly("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.16:dev")
     compileOnly(deobfCurse('terrafirmacraft-302973:2627990')) {transitive = false}
     compileOnly(deobfCurse('terrafirmacraftplus-287053:3779225')) {transitive = false}
     compileOnly("org.jetbrains:annotations:24.0.1")
-    compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.10-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.12-GTNH:dev") {transitive = false}
     compileOnly(deobfCurse("bibliocraft-228027:2423369")) {transitive = false}
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.14-GTNH:dev') {transitive = false}
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
     compileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
-    compileOnly("com.github.GTNewHorizons:CropsNH:2.0.49:dev")
+    compileOnly("com.github.GTNewHorizons:CropsNH:2.0.53:dev")
 
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.7-backhand:dev") {
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.8-backhand:dev") {
         exclude module: "Backhand"
     }
 }

--- a/src/main/java/xonin/backhand/compat/CropsNHCompat.java
+++ b/src/main/java/xonin/backhand/compat/CropsNHCompat.java
@@ -24,7 +24,8 @@ public class CropsNHCompat {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onPlayerInteract(PlayerInteractEvent event) {
-        if (event.world == null || event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || !BackhandUtils.isUsingOffhand(event.entityPlayer)) return;
+        if (event.world == null || event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK
+            || !BackhandUtils.isUsingOffhand(event.entityPlayer)) return;
         ItemStack mainHand = MAIN_HAND.getItem(event.entityPlayer);
         if (mainHand == null || !(mainHand.getItem() instanceof ItemWateringCan)) return;
         if (event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {

--- a/src/main/java/xonin/backhand/compat/CropsNHCompat.java
+++ b/src/main/java/xonin/backhand/compat/CropsNHCompat.java
@@ -1,0 +1,34 @@
+package xonin.backhand.compat;
+
+import static xonin.backhand.api.core.EnumHand.MAIN_HAND;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import com.gtnewhorizon.cropsnh.blocks.BlockCropSticks;
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
+import com.rwtema.extrautils.item.ItemWateringCan;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import xonin.backhand.api.core.BackhandUtils;
+import xonin.backhand.utils.Mods;
+
+@EventBusSubscriber
+public class CropsNHCompat {
+
+    @EventBusSubscriber.Condition
+    public static boolean register() {
+        return Mods.CROPSNH.isLoaded() && Mods.EXTRA_UTILITIES.isLoaded();
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.world == null || event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || !BackhandUtils.isUsingOffhand(event.entityPlayer)) return;
+        ItemStack mainHand = MAIN_HAND.getItem(event.entityPlayer);
+        if (mainHand == null || !(mainHand.getItem() instanceof ItemWateringCan)) return;
+        if (event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/xonin/backhand/utils/Mods.java
+++ b/src/main/java/xonin/backhand/utils/Mods.java
@@ -11,7 +11,8 @@ public enum Mods {
     TFCPLUS("terrafirmacraftplus"),
     THAUMCRAFT("Thaumcraft"),
     BIBLIOCRAFT("BiblioCraft"),
-    EXTRA_UTILITIES("ExtraUtilities");
+    EXTRA_UTILITIES("ExtraUtilities"),
+    CROPSNH("cropsnh"),;
 
     private final String modId;
     private Boolean loaded;


### PR DESCRIPTION
Cancels the offhand action whenever a crop stick block from CropsNH is targeted while holding a watering can from ExU.

Addresses https://discordapp.com/channels/181078474394566657/401118216228831252/1502146611524931666