### PR TITLE
Fix backhand still triggering on cancelled interactions and causing them to fire twice

### DIFF
--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -79,6 +79,7 @@ public abstract class MixinMinecraft {
      *         Don't change this methods visibility despite what mixin debug says.
      *         Some mods AT this and changing the visibility will break them.
      */
+    @SuppressWarnings("visibility")
     @Overwrite
     public void func_147121_ag() {
         rightClickDelayTimer = 4;

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -70,6 +70,8 @@ public abstract class MixinMinecraft {
 
     @Unique
     private int backhand$breakBlockTimer = 0;
+    @Unique
+    private boolean backhand$blockRightClickCanceled;
 
     /**
      * @author Lyft
@@ -110,6 +112,12 @@ public abstract class MixinMinecraft {
 
             if (blockHit) {
                 if (backhand$useRightClick(hand, handStack, stack -> backhand$rightClickBlock(stack, x, y, z))) {
+                    return;
+                }
+                if (backhand$blockRightClickCanceled) {
+                    if (handStack != null) {
+                        backhand$useRightClick(hand, handStack, this::backhand$rightClickItem);
+                    }
                     return;
                 }
             } else if (entityHit) {
@@ -251,7 +259,8 @@ public abstract class MixinMinecraft {
             z,
             objectMouseOver.sideHit,
             theWorld);
-        if (!MinecraftForge.EVENT_BUS.post(useItemEvent) && playerController
+        backhand$blockRightClickCanceled = MinecraftForge.EVENT_BUS.post(useItemEvent);
+        if (!backhand$blockRightClickCanceled && playerController
             .onPlayerRightClick(thePlayer, theWorld, stack, x, y, z, objectMouseOver.sideHit, objectMouseOver.hitVec)) {
             thePlayer.swingItem();
             return true;


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25739

Some mods cancel interactions to then do it their own way.
Backhand wasn't checking for it, going through to do it's own thing and while trying to do offhand interaction causing main hand item interaction to possibly even happen twice.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
