### PR TITLE
Fix crash when using Witchery brew bag from offhand

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,7 +45,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.16:dev")
     compileOnly(deobfCurse('terrafirmacraft-302973:2627990')) {transitive = false}
     compileOnly(deobfCurse('terrafirmacraftplus-287053:3779225')) {transitive = false}
-    compileOnly("org.jetbrains:annotations:24.0.1")
+    compileOnly("org.jetbrains:annotations:26.1.0")
     compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.13-GTNH:dev") {transitive = false}
     compileOnly(deobfCurse("bibliocraft-228027:2423369")) {transitive = false}
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") {transitive = false}
@@ -53,6 +53,7 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
     compileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
+    compileOnly(rfg.deobf("curse.maven:witchery-69673:2234410"))
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Battlegear2-for-Backhand:1.6.8-backhand:dev") {
         exclude module: "Backhand"

--- a/src/main/java/xonin/backhand/mixins/Mixins.java
+++ b/src/main/java/xonin/backhand/mixins/Mixins.java
@@ -93,7 +93,13 @@ public enum Mixins implements IMixins {
             .addCommonMixins(
                 "ic2.MixinSlotArmor")
             .setPhase(Phase.LATE)
-            .addRequiredMod(TargetedMod.IC2));
+            .addRequiredMod(TargetedMod.IC2)),
+    WITCHERY_FIX_BREW_BAG_CRASH(
+        new MixinBuilder("Fix crash when using brew bag from offhand")
+            .addCommonMixins(
+                "witchery.MixinInventoryBrewBag")
+            .setPhase(Phase.LATE)
+            .addRequiredMod(TargetedMod.WITCHERY));
     // spotless:on
 
     private final MixinBuilder builder;

--- a/src/main/java/xonin/backhand/mixins/TargetedMod.java
+++ b/src/main/java/xonin/backhand/mixins/TargetedMod.java
@@ -16,7 +16,8 @@ public enum TargetedMod implements ITargetMod {
     TINKERS_CONSTRUCT("TConstruct"),
     MINECRAFT_BACKPACK_MOD("Backpack"),
     THAUMCRAFT("Thaumcraft"),
-    IC2("IC2");
+    IC2("IC2"),
+    WITCHERY("witchery");
 
     private final TargetModBuilder builder;
 

--- a/src/main/java/xonin/backhand/mixins/late/witchery/MixinInventoryBrewBag.java
+++ b/src/main/java/xonin/backhand/mixins/late/witchery/MixinInventoryBrewBag.java
@@ -1,0 +1,31 @@
+package xonin.backhand.mixins.late.witchery;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.emoniph.witchery.item.ItemBrewBag;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import xonin.backhand.api.core.BackhandUtils;
+
+@Mixin(value = ItemBrewBag.InventoryBrewBag.class, remap = false)
+public class MixinInventoryBrewBag {
+
+    @Shadow
+    protected EntityPlayer player;
+
+    @ModifyExpressionValue(
+        method = { "hasInventory", "createInventory" },
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/player/EntityPlayer;getHeldItem()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack backhand$fixBrewBagCrash(ItemStack original) {
+        if (original != null && original.getItem() instanceof ItemBrewBag) return original;
+        ItemStack offhand = BackhandUtils.getOffhandItem(player);
+        return (offhand != null && offhand.getItem() instanceof ItemBrewBag) ? offhand : original;
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Witchery does some absurdly silly stuff such as using render events to open bags which caused the crash.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25713

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
