### PR TITLE
Fix several offhand issues

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.93-GTNH:dev") {transitive = false}
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.106-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev") {transitive = false}
-    compileOnly(rfg.deobf('maven.modrinth:etfuturum:2.6.2')) {transitive = false}
+    compileOnly("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.48-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Draconic-Evolution:1.5.27-GTNH:dev") {transitive = false}
     // pulls in ae2 for the mixin dep

--- a/src/main/java/xonin/backhand/Backhand.java
+++ b/src/main/java/xonin/backhand/Backhand.java
@@ -57,21 +57,17 @@ public class Backhand {
     }
 
     public static boolean isOffhandBlacklisted(ItemStack stack) {
-        if (stack == null) return false;
-
-        for (String itemName : BackhandConfig.offhandBlacklist) {
-            if (stack.getItem().delegate.name()
-                .equals(itemName)) {
-                return true;
-            }
-        }
-        return false;
+        return matchesItemName(stack, BackhandConfig.offhandBlacklist);
     }
 
     public static boolean doesMainhandUseStopOffhandFallback(ItemStack stack) {
+        return matchesItemName(stack, BackhandConfig.mainhandUseStopsOffhandFallback);
+    }
+
+    private static boolean matchesItemName(ItemStack stack, String[] itemNames) {
         if (stack == null) return false;
 
-        for (String itemName : BackhandConfig.mainhandUseStopsOffhandFallback) {
+        for (String itemName : itemNames) {
             if (stack.getItem().delegate.name()
                 .equals(itemName)) {
                 return true;

--- a/src/main/java/xonin/backhand/Backhand.java
+++ b/src/main/java/xonin/backhand/Backhand.java
@@ -67,4 +67,16 @@ public class Backhand {
         }
         return false;
     }
+
+    public static boolean doesMainhandUseStopOffhandFallback(ItemStack stack) {
+        if (stack == null) return false;
+
+        for (String itemName : BackhandConfig.mainhandUseStopsOffhandFallback) {
+            if (stack.getItem().delegate.name()
+                .equals(itemName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/xonin/backhand/mixins/Mixins.java
+++ b/src/main/java/xonin/backhand/mixins/Mixins.java
@@ -84,6 +84,8 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.MINECRAFT_BACKPACK_MOD)),
     TC_BACKHAND_COMPAT(
         new MixinBuilder("Backhand compat for TC wands & Thaumometer")
+            .addCommonMixins(
+                "thaumcraft.MixinEntityAspectOrb")
             .addClientMixins(
                 "thaumcraft.MixinClientTickEventsFML", "thaumcraft.MixinTileNodeRenderer")
             .setPhase(Phase.LATE)

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -13,6 +13,7 @@ import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
@@ -68,10 +69,15 @@ public abstract class MixinMinecraft {
     @Shadow
     public EffectRenderer effectRenderer;
 
+    @Shadow
+    public GameSettings gameSettings;
+
     @Unique
     private int backhand$breakBlockTimer = 0;
     @Unique
     private boolean backhand$blockRightClickCanceled;
+    @Unique
+    private boolean backhand$suppressNextOffhandBreakSwing;
 
     /**
      * @author Lyft
@@ -161,7 +167,7 @@ public abstract class MixinMinecraft {
         }
 
         if (BackhandConfig.OffhandAttack && objectMouseOver.typeOfHit == MovingObjectType.ENTITY
-            && offhandItem != null) {
+            && backhand$canUseOffhand(mainHandItem, offhandItem)) {
             BackhandUtils.useOffhandItem(thePlayer, () -> {
                 rightClickDelayTimer = 10;
                 thePlayer.swingItem();
@@ -170,11 +176,10 @@ public abstract class MixinMinecraft {
             return;
         }
 
-        if (BackhandConfig.OffhandBreakBlocks && blockHit
-            && offhandItem != null
-            && BackhandUtils.isItemTool(offhandItem.getItem())) {
+        if (BackhandConfig.OffhandBreakBlocks && blockHit && backhand$canBreakWithOffhand(mainHandItem, offhandItem)) {
             BackhandUtils.useOffhandItem(thePlayer, () -> {
                 backhand$breakBlockTimer = 5;
+                backhand$suppressNextOffhandBreakSwing = true;
                 playerController.clickBlock(x, y, z, objectMouseOver.sideHit);
             });
         }
@@ -187,6 +192,11 @@ public abstract class MixinMinecraft {
             target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;resetBlockRemoving()V"))
     private boolean backhand$pauseReset(PlayerControllerMP instance) {
         if (backhand$breakBlockTimer > 0) {
+            if (!gameSettings.keyBindUseItem.getIsKeyPressed()) {
+                backhand$breakBlockTimer = 0;
+                backhand$suppressNextOffhandBreakSwing = false;
+                return true;
+            }
             backhand$breakBlockTimer--;
             return false;
         }
@@ -196,6 +206,11 @@ public abstract class MixinMinecraft {
     @Inject(method = "func_147115_a", at = @At(value = "HEAD"))
     private void backhand$breakBlockOffhand(boolean leftClick, CallbackInfo ci) {
         if (backhand$breakBlockTimer > 0) {
+            if (!gameSettings.keyBindUseItem.getIsKeyPressed()) {
+                backhand$breakBlockTimer = 0;
+                backhand$suppressNextOffhandBreakSwing = false;
+                return;
+            }
             BackhandUtils.useOffhandItem(thePlayer, () -> {
                 int i = objectMouseOver.blockX;
                 int j = objectMouseOver.blockY;
@@ -207,7 +222,13 @@ public abstract class MixinMinecraft {
 
                     if (thePlayer.isCurrentToolAdventureModeExempt(i, j, k)) {
                         effectRenderer.addBlockHitEffects(i, j, k, objectMouseOver);
-                        thePlayer.swingItem();
+                        if (backhand$suppressNextOffhandBreakSwing) {
+                            backhand$suppressNextOffhandBreakSwing = false;
+                        } else {
+                            thePlayer.swingItem();
+                        }
+                    } else {
+                        backhand$suppressNextOffhandBreakSwing = false;
                     }
                 }
             });
@@ -217,6 +238,17 @@ public abstract class MixinMinecraft {
     @ModifyExpressionValue(method = "func_147112_ai", at = @At(value = "INVOKE", target = "Ljava/util/List;size()I"))
     private int backhand$adjustSlotOffset(int original) {
         return original - 1;
+    }
+
+    @Unique
+    private boolean backhand$canUseOffhand(ItemStack mainHandItem, ItemStack offhandItem) {
+        return offhandItem != null || mainHandItem == null && BackhandConfig.EmptyOffhand;
+    }
+
+    @Unique
+    private boolean backhand$canBreakWithOffhand(ItemStack mainHandItem, ItemStack offhandItem) {
+        return offhandItem != null ? BackhandUtils.isItemTool(offhandItem.getItem())
+            : mainHandItem == null && BackhandConfig.EmptyOffhand;
     }
 
     @Unique

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -97,8 +97,8 @@ public abstract class MixinMinecraft {
 
         ItemStack mainHandItem = MAIN_HAND.getItem(thePlayer);
         ItemStack offhandItem = OFF_HAND.getItem(thePlayer);
-        EnumHand[] hands = Backhand.doesMainhandUseStopOffhandFallback(mainHandItem)
-            || !backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS : HANDS_REV;
+        EnumHand[] hands = !Backhand.doesMainhandUseStopOffhandFallback(mainHandItem)
+            && backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
 
         int x = objectMouseOver.blockX;
         int y = objectMouseOver.blockY;
@@ -151,6 +151,9 @@ public abstract class MixinMinecraft {
                 }
                 if (hand == MAIN_HAND) {
                     mainHandUsedFluid = true;
+                    if (backhand$doesMainhandUseStopOffhandFallback(hand, handStack)) {
+                        return;
+                    }
                 } else {
                     offhandUsedFluid = true;
                 }
@@ -201,11 +204,6 @@ public abstract class MixinMinecraft {
             target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;resetBlockRemoving()V"))
     private boolean backhand$pauseReset(PlayerControllerMP instance) {
         if (backhand$breakBlockTimer > 0) {
-            if (!gameSettings.keyBindUseItem.getIsKeyPressed()) {
-                backhand$breakBlockTimer = 0;
-                backhand$suppressNextOffhandBreakSwing = false;
-                return true;
-            }
             backhand$breakBlockTimer--;
             return false;
         }
@@ -231,14 +229,11 @@ public abstract class MixinMinecraft {
 
                     if (thePlayer.isCurrentToolAdventureModeExempt(i, j, k)) {
                         effectRenderer.addBlockHitEffects(i, j, k, objectMouseOver);
-                        if (backhand$suppressNextOffhandBreakSwing) {
-                            backhand$suppressNextOffhandBreakSwing = false;
-                        } else {
+                        if (!backhand$suppressNextOffhandBreakSwing) {
                             thePlayer.swingItem();
                         }
-                    } else {
-                        backhand$suppressNextOffhandBreakSwing = false;
                     }
+                    backhand$suppressNextOffhandBreakSwing = false;
                 }
             });
         }

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 
+import xonin.backhand.Backhand;
 import xonin.backhand.api.core.BackhandUtils;
 import xonin.backhand.api.core.EnumHand;
 import xonin.backhand.client.utils.BackhandRenderHelper;
@@ -127,6 +128,10 @@ public abstract class MixinMinecraft {
                     }
                     return;
                 }
+                if (backhand$doesMainhandUseStopOffhandFallback(hand, handStack)) {
+                    backhand$useRightClick(hand, handStack, this::backhand$rightClickItem);
+                    return;
+                }
             } else if (entityHit) {
                 if (backhand$useRightClick(
                     hand,
@@ -162,6 +167,9 @@ public abstract class MixinMinecraft {
                 handStack = offhandItem;
             }
             if (backhand$useRightClick(hand, handStack, this::backhand$rightClickItem)) {
+                return;
+            }
+            if (backhand$doesMainhandUseStopOffhandFallback(hand, handStack)) {
                 return;
             }
         }
@@ -249,6 +257,11 @@ public abstract class MixinMinecraft {
     private boolean backhand$canBreakWithOffhand(ItemStack mainHandItem, ItemStack offhandItem) {
         return offhandItem != null ? BackhandUtils.isItemTool(offhandItem.getItem())
             : mainHandItem == null && BackhandConfig.EmptyOffhand;
+    }
+
+    @Unique
+    private boolean backhand$doesMainhandUseStopOffhandFallback(EnumHand hand, ItemStack stack) {
+        return hand == MAIN_HAND && Backhand.doesMainhandUseStopOffhandFallback(stack);
     }
 
     @Unique

--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinMinecraft.java
@@ -97,7 +97,8 @@ public abstract class MixinMinecraft {
 
         ItemStack mainHandItem = MAIN_HAND.getItem(thePlayer);
         ItemStack offhandItem = OFF_HAND.getItem(thePlayer);
-        EnumHand[] hands = backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS_REV : HANDS;
+        EnumHand[] hands = Backhand.doesMainhandUseStopOffhandFallback(mainHandItem)
+            || !backhand$doesOffhandNeedPriority(mainHandItem, offhandItem) ? HANDS : HANDS_REV;
 
         int x = objectMouseOver.blockX;
         int y = objectMouseOver.blockY;

--- a/src/main/java/xonin/backhand/mixins/late/thaumcraft/MixinEntityAspectOrb.java
+++ b/src/main/java/xonin/backhand/mixins/late/thaumcraft/MixinEntityAspectOrb.java
@@ -1,0 +1,42 @@
+package xonin.backhand.mixins.late.thaumcraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.common.entities.EntityAspectOrb;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import xonin.backhand.api.core.BackhandUtils;
+
+@Mixin(value = EntityAspectOrb.class, remap = false)
+public abstract class MixinEntityAspectOrb {
+
+    @WrapOperation(
+        method = { "onUpdate", "onCollideWithPlayer" },
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/lib/utils/InventoryUtils;isWandInHotbarWithRoom(Lthaumcraft/api/aspects/Aspect;ILnet/minecraft/entity/player/EntityPlayer;)I",
+            remap = false),
+        remap = true)
+    private int backhand$includeOffhandWand(Aspect aspect, int amount, EntityPlayer player,
+        Operation<Integer> original) {
+        int slot = original.call(aspect, amount, player);
+        if (slot >= 0) {
+            return slot;
+        }
+
+        ItemStack offhand = BackhandUtils.getOffhandItem(player);
+        if (offhand != null && offhand.getItem() instanceof ItemWandCasting wand
+            && wand.addVis(offhand, aspect, amount, false) < amount) {
+            return BackhandUtils.getOffhandSlot(player);
+        }
+
+        return -1;
+    }
+}

--- a/src/main/java/xonin/backhand/utils/BackhandConfig.java
+++ b/src/main/java/xonin/backhand/utils/BackhandConfig.java
@@ -31,6 +31,24 @@ public class BackhandConfig {
     @Config.DefaultStringList({})
     public static String[] offhandBlacklist;
 
+    @Config.Sync
+    @Config.Comment("""
+        Main hand items listed here stop Backhand from trying the offhand fallback after right click.
+        This does not stop the item from being held in the offhand; use offhandBlacklist for that.
+        Use this for server-authoritative tools that act on the server but return false on the client.
+        Formatting of an item should be: modid:itemname
+        """)
+    @Config.DefaultStringList({ "matter-manipulator:itemMatterManipulator0",
+        "matter-manipulator:itemMatterManipulator1", "matter-manipulator:itemMatterManipulator2",
+        "matter-manipulator:itemMatterManipulator3", "Forestry:beealyzer", "Forestry:solderingIron",
+        "Forestry:apiaristBag", "Forestry:lepidopteristBag", "Forestry:minerBag", "Forestry:minerBagT2",
+        "Forestry:diggerBag", "Forestry:diggerBagT2", "Forestry:foresterBag", "Forestry:foresterBagT2",
+        "Forestry:hunterBag", "Forestry:hunterBagT2", "Forestry:adventurerBag", "Forestry:adventurerBagT2",
+        "Forestry:builderBag", "Forestry:builderBagT2", "Forestry:coinBag", "Forestry:coinBagT2",
+        "DraconicEvolution:magnet", "appliedenergistics2:item.ToolNetworkTool",
+        "appliedenergistics2:item.ToolAdvancedNetworkTool" })
+    public static String[] mainhandUseStopsOffhandFallback;
+
     @Config.Comment("Picked up items can go into the offhand slot when empty. False in vanilla")
     @Config.DefaultBoolean(false)
     public static boolean OffhandPickup;


### PR DESCRIPTION
## Summary

I wrote this 3 weeks ago with the intend to push it after my previous PR and I completely forgot about it.
That said giving it a test just now I found some edge cases to fix.

Hopefully should improve a bunch of things in the list here https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22178

### Fix Interaction fall through

It should now handle properly: canceled right-click block interactions, server side main hand tool for which right click return false to the client, and a few more edge cases.

- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21886
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21923
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22157
- Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20627

### Added main hand fallback block list

This add a new config: `mainhandUseStopsOffhandFallback`
This doesn't stop using said items in offhand (there is already a config for that), but hard block any offhand interaction while they are in main hand due to having complicated handling
Default entries cover known problematic server-authoritative tools, including Matter Manipulator tiers, Forestry handheld GUIs/backpacks, Draconic Evolution item dislocator, and AE2 network tools.

### Fix Thaumcraft vis orb pickup

Allow offhand wand to pickup vis orb

- Fixes https://github.com/GTNewHorizons/Backhand/issues/164


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
