### PR TITLE
avoid index out of bounds on getting offhand item

### DIFF
--- a/src/main/java/xonin/backhand/mixins/early/minecraft/MixinInventoryPlayer.java
+++ b/src/main/java/xonin/backhand/mixins/early/minecraft/MixinInventoryPlayer.java
@@ -125,7 +125,11 @@ public abstract class MixinInventoryPlayer implements IOffhandInventory {
 
     @Override
     public ItemStack backhand$getOffhandItem() {
-        return mainInventory[backhand$getOffhandSlot()];
+        final int slotIndex = backhand$getOffhandSlot();
+        if (slotIndex >= 0 && slotIndex < mainInventory.length) {
+            return mainInventory[slotIndex];
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary

This adds a sanity check to avoid a possible exception whenever the inventory is not the correct size.

This can happen because mods, like Thermal Expansion, simulates left click and also simulates an player inventory, but without backhand.

<details>

<summary>Stack trace without this fix</summary>

```
java.lang.ArrayIndexOutOfBoundsException: Index 36 out of bounds for length 36
	at Launch//net.minecraft.entity.player.InventoryPlayer.backhand$getOffhandItem(InventoryPlayer.java:1420)
	at Launch//xonin.backhand.api.core.BackhandUtils.getOffhandItem(BackhandUtils.java:40)
	at Launch//iguanaman.iguanatweakstconstruct.leveling.handlers.LevelingEventHandler.onHurt(LevelingEventHandler.java:58)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1321_LevelingEventHandler_onHurt_LivingHurtEvent.invoke(.dynamic)
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at Launch//net.minecraftforge.common.ForgeHooks.onLivingHurt(ForgeHooks.java:298)
	at Launch//net.minecraft.entity.player.EntityPlayer.func_70665_d(EntityPlayer.java:1080)
	at Launch//net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:785)
	at Launch//net.minecraft.entity.player.EntityPlayer.func_70097_a(EntityPlayer.java:1034)
	at Launch//net.minecraft.entity.player.EntityPlayerMP.func_70097_a(EntityPlayerMP.java:491)
	at Launch//net.minecraft.entity.player.EntityPlayer.func_71059_n(EntityPlayer.java:1232)
	at Launch//org.embeddedt.archaicfix.LeftClickEventHandler.onLeftClick(LeftClickEventHandler.java:40)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_274_LeftClickEventHandler_onLeftClick_PlayerInteractEvent.invoke(.dynamic)
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at Launch//net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(ForgeEventFactory.java:100)
	at Launch//net.minecraft.server.management.ItemInWorldManager.func_73074_a(ItemInWorldManager.java:140)
	at Launch//cofh.thermalexpansion.block.device.TileActivator.simLeftClick(TileActivator.java:341)
	at Launch//cofh.thermalexpansion.block.device.TileActivator.doDeploy(TileActivator.java:188)
	at Launch//cofh.thermalexpansion.block.device.TileActivator.func_145845_h(TileActivator.java:150)
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1939)
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:396)
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```

</details>

Feel free to implement the fix on a different way, if you feel like. :)

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
